### PR TITLE
MacOS compatibility

### DIFF
--- a/Disruptor/CMakeLists.txt
+++ b/Disruptor/CMakeLists.txt
@@ -1,6 +1,8 @@
 project(Disruptor)
 cmake_minimum_required(VERSION 2.6)
 
+include(GNUInstallDirs)
+
 find_package(Boost COMPONENTS system thread chrono)
 if(Boost_FOUND)
     include_directories(${Boost_INCLUDE_DIRS})
@@ -125,8 +127,8 @@ set_target_properties(DisruptorShared PROPERTIES SOVERSION ${DISRUPTOR_VERSION_M
 add_library(DisruptorStatic STATIC ${Disruptor_sources})
 set_target_properties(DisruptorStatic PROPERTIES OUTPUT_NAME Disruptor)
 
-install(FILES ${Disruptor_headers} DESTINATION include/Disruptor)
-install(FILES ${Disruptor_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+# install(FILES ${Disruptor_headers} DESTINATION include/Disruptor)
+install(FILES ${Disruptor_headers} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/Disruptor)
 
 install(TARGETS DisruptorShared DisruptorStatic
     LIBRARY DESTINATION lib

--- a/Disruptor/SpinWait.cpp
+++ b/Disruptor/SpinWait.cpp
@@ -111,12 +111,13 @@ namespace Disruptor
     }
 
     void SpinWait::yieldProcessor()
-    {
+    {       
 #if defined(DISRUPTOR_VC_COMPILER)
 
         ::YieldProcessor();
 
-#elif defined(DISRUPTOR_GNUC_COMPILER)
+// #elif defined(DISRUPTOR_GNUC_COMPILER)
+#elif defined(__i386__) || defined(__x86_64__)
 
         asm volatile
             (
@@ -126,7 +127,7 @@ namespace Disruptor
 
 #else
 
-# error "Unsupported platform"
+        std::this_thread::yield();
 
 #endif
     }

--- a/Disruptor/ThreadHelper_macOS.cpp
+++ b/Disruptor/ThreadHelper_macOS.cpp
@@ -10,7 +10,9 @@
 #include <pthread.h>
 #include <unistd.h>
 #include <sched.h>
+#if defined(__i386__) || defined(__x86_64__)
 #include <cpuid.h>
+#endif // defined(__i386__) || defined(__x86_64__)
 #include <sys/sysctl.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
@@ -94,8 +96,12 @@ namespace ThreadHelper
     {
         uint32_t cpu_id;
 
+#ifdef __cpuid_count
         GETCPU(cpu_id);
-
+#else
+        // Apple silicon does not define __cpuid_count so we must skip it.
+        cpu_id = 0;
+#endif // __cpuid_count
         return cpu_id;
     }
 

--- a/Disruptor/TypeInfo.h
+++ b/Disruptor/TypeInfo.h
@@ -50,7 +50,8 @@ namespace std
 {
 
     template <>
-    struct hash< Disruptor::TypeInfo > : public unary_function< Disruptor::TypeInfo, size_t >
+    // struct hash< Disruptor::TypeInfo > : public unary_function< Disruptor::TypeInfo, size_t >
+    struct hash< Disruptor::TypeInfo >
     {
     public:
         size_t operator()(const Disruptor::TypeInfo& value) const


### PR DESCRIPTION
A few changes to allow this to compile on MacOS 14.1 with the default clang compiler. 

NOTE: one change made here is to install header files ONLY in the include/Disruptor directory. This is not a mac-specific change and will affect all platforms. The previous behavior installed all headers in *both* include and include/Disruptor.
