### PR TITLE
Update minimum CMake version to 3.22

### DIFF
--- a/Disruptor/CMakeLists.txt
+++ b/Disruptor/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(Disruptor)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.22)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
(now updated in Disruptor src file, not just top-level file)